### PR TITLE
Add support for WASD key movement

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -105,10 +105,10 @@
 			camera.attachControl(canvas, false);
 
 			// Push WASD keys to camera control key arrays so they can be used for movement
-			camera.keysUp.push(87); //w
-			camera.keysDown.push(83); //s
-			camera.keysLeft.push(65); //a
-			camera.keysRight.push(68); //d
+			camera.keysUp.push(87); // W
+			camera.keysDown.push(83); // S
+			camera.keysLeft.push(65); // A
+			camera.keysRight.push(68); // D
 			
 			// This creates a light, aiming 0,1,0 - to the sky.
 			var light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -104,6 +104,12 @@
 			// This attaches the camera to the canvas
 			camera.attachControl(canvas, false);
 
+			// Push WASD keys to camera control key arrays so they can be used for movement
+			camera.keysUp.push(87); //w
+			camera.keysDown.push(83); //s
+			camera.keysLeft.push(65); //a
+			camera.keysRight.push(68); //d
+			
 			// This creates a light, aiming 0,1,0 - to the sky.
 			var light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);
 


### PR DESCRIPTION
This pull changes adds four funtional lines that push the `WASD` keys to the arrays of supported movement keys in the `FreeCamera` object `camera`.

The `FreeCamera` has arrays of keys for up, down, left, and right movements (named `FreeCamera.keysUp`, `FreeCamera.keysDown`, etc...). This pull simply pushes additional keys into these arrays so that they can be used in conjunction to the arrow keys. This way users can choose which control set they feel most comfortable with.
